### PR TITLE
Blacklist additional props in getDomProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -276,11 +276,13 @@ export default class VirtualList extends React.PureComponent<Props, State> {
 
   getDomProps() {
     const {
+      estimatedItemSize,
       scrollToAlignment,
       scrollOffset,
       itemCount,
       itemSize,
       onScroll,
+      onItemsRendered,
       renderItem,
       overscanCount,
       scrollDirection,


### PR DESCRIPTION
The props `estimatedItemSize` and `onItemsRendered` are being passed down to the DOM element unintentionally and cause React warnings when they're provided. This PR adds those two to the getDomProps blacklist.